### PR TITLE
[FEAT] Rename modes: development->self-hosted, production->valyu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,44 +8,19 @@
 # ------------------------------------------------------------------------------
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------
-# Set to 'development' or 'production'
-# development = no auth, local SQLite, unlimited queries
-# production = full auth, Supabase, Valyu OAuth
-NEXT_PUBLIC_APP_MODE=development
+# Set to 'self-hosted' or 'valyu'
+# self-hosted = no auth, local SQLite, unlimited queries, use your own API key
+# valyu = full auth, Supabase, Valyu OAuth (hosted at history.valyu.ai)
+NEXT_PUBLIC_APP_MODE=self-hosted
 
 # Your app URL (use http://localhost:3000 for local development)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # ------------------------------------------------------------------------------
-# VALYU OAUTH CONFIGURATION (REQUIRED FOR PRODUCTION)
+# VALYU API KEY (REQUIRED FOR SELF-HOSTED MODE)
 # ------------------------------------------------------------------------------
-# "Sign in with Valyu" OAuth 2.1 credentials
-# Get these from: https://platform.valyu.ai → Settings → OAuth Apps
-#
-# Only 4 variables needed - NO Valyu anon key required!
-#
-# Endpoint usage:
-#   VALYU_SUPABASE_URL → OAuth endpoints (/auth/v1/authorize, /auth/v1/token, /auth/v1/user)
-#   VALYU_APP_URL → Platform API proxy (/api/oauth/proxy)
-
-# Valyu Platform's Supabase URL (for OAuth endpoints)
-NEXT_PUBLIC_VALYU_SUPABASE_URL=https://wqrkdlceexqaqqvjbjxp.supabase.co
-
-# Your OAuth Client ID (public - also used as apikey for Supabase auth calls)
-NEXT_PUBLIC_VALYU_CLIENT_ID=your_oauth_client_id_here
-
-# Your OAuth Client Secret (KEEP SECRET - server-side only, for token exchange)
-VALYU_CLIENT_SECRET=your_oauth_client_secret_here
-
-# Valyu Platform URL for API proxy (default: https://platform.valyu.ai)
-VALYU_APP_URL=https://platform.valyu.ai
-
-# ------------------------------------------------------------------------------
-# DEEPRESEARCH / VALYU API (OPTIONAL - Dev Fallback)
-# ------------------------------------------------------------------------------
-# Only needed for development mode when no OAuth token is available
-# In production, API calls go through the Valyu OAuth Proxy
 # Get your API key at: https://platform.valyu.ai
+# This is the primary way to use the app in self-hosted mode
 VALYU_API_KEY=valyu_your_api_key_here
 
 # ------------------------------------------------------------------------------
@@ -56,28 +31,6 @@ VALYU_API_KEY=valyu_your_api_key_here
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.your_mapbox_access_token_here
 
 # ------------------------------------------------------------------------------
-# APP'S SUPABASE (REQUIRED FOR PRODUCTION)
-# ------------------------------------------------------------------------------
-# Your app's own Supabase for storing user data, chat history, etc.
-# This is separate from Valyu's Supabase (which handles OAuth)
-# Get these from: https://supabase.com → Project Settings → API
-
-# Your Supabase project URL
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-
-# Supabase anonymous (public) key
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
-
-# Supabase service role key (KEEP SECRET - never expose client-side)
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
-
-# ------------------------------------------------------------------------------
-# ENTERPRISE FEATURES (OPTIONAL)
-# ------------------------------------------------------------------------------
-# Set to 'true' to enable enterprise contact options (banner, sidebar button, etc.)
-NEXT_PUBLIC_ENTERPRISE=false
-
-# ------------------------------------------------------------------------------
 # OPENAI API (OPTIONAL)
 # ------------------------------------------------------------------------------
 # Used for AI-powered location image selection and optimization
@@ -86,24 +39,72 @@ NEXT_PUBLIC_ENTERPRISE=false
 OPENAI_API_KEY=sk-your_openai_api_key_here
 
 # ------------------------------------------------------------------------------
+# VALYU OAUTH CONFIGURATION (VALYU MODE ONLY)
+# ------------------------------------------------------------------------------
+# NOTE: Valyu OAuth apps will be in general availability soon.
+# Currently client id/secret are not publicly available.
+# Contact contact@valyu.ai if you need access.
+#
+# "Sign in with Valyu" OAuth 2.1 credentials
+# Only 4 variables needed - NO Valyu anon key required!
+#
+# Endpoint usage:
+#   VALYU_SUPABASE_URL -> OAuth endpoints (/auth/v1/authorize, /auth/v1/token, /auth/v1/user)
+#   VALYU_APP_URL -> Platform API proxy (/api/oauth/proxy)
+
+# Valyu Platform's Supabase URL (for OAuth endpoints)
+# NEXT_PUBLIC_VALYU_SUPABASE_URL=https://wqrkdlceexqaqqvjbjxp.supabase.co
+
+# Your OAuth Client ID (public - also used as apikey for Supabase auth calls)
+# NEXT_PUBLIC_VALYU_CLIENT_ID=your_oauth_client_id_here
+
+# Your OAuth Client Secret (KEEP SECRET - server-side only, for token exchange)
+# VALYU_CLIENT_SECRET=your_oauth_client_secret_here
+
+# Valyu Platform URL for API proxy (default: https://platform.valyu.ai)
+# VALYU_APP_URL=https://platform.valyu.ai
+
+# ------------------------------------------------------------------------------
+# APP'S SUPABASE (VALYU MODE ONLY)
+# ------------------------------------------------------------------------------
+# Your app's own Supabase for storing user data, chat history, etc.
+# This is separate from Valyu's Supabase (which handles OAuth)
+# Get these from: https://supabase.com -> Project Settings -> API
+
+# Your Supabase project URL
+# NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+
+# Supabase anonymous (public) key
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+
+# Supabase service role key (KEEP SECRET - never expose client-side)
+# SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+
+# ------------------------------------------------------------------------------
+# ENTERPRISE FEATURES (OPTIONAL)
+# ------------------------------------------------------------------------------
+# Set to 'true' to enable enterprise contact options (banner, sidebar button, etc.)
+NEXT_PUBLIC_ENTERPRISE=false
+
+# ------------------------------------------------------------------------------
 # ANALYTICS (OPTIONAL)
 # ------------------------------------------------------------------------------
 # PostHog for analytics and feature flags
 # Get these from: https://posthog.com
-NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
-NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+# NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
+# NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
 # ------------------------------------------------------------------------------
 # EXAMPLE CONFIGURATIONS
 # ------------------------------------------------------------------------------
 
-# Development Mode (Easy Setup - No Auth):
-# NEXT_PUBLIC_APP_MODE=development
+# Self-Hosted Mode (Recommended - Easy Setup):
+# NEXT_PUBLIC_APP_MODE=self-hosted
 # VALYU_API_KEY=valyu_xxx
 # NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.xxx
 
-# Production Mode (Full Setup - Valyu OAuth):
-# NEXT_PUBLIC_APP_MODE=production
+# Valyu Mode (OAuth - Contact contact@valyu.ai for access):
+# NEXT_PUBLIC_APP_MODE=valyu
 # NEXT_PUBLIC_APP_URL=https://yourdomain.com
 # NEXT_PUBLIC_VALYU_SUPABASE_URL=https://wqrkdlceexqaqqvjbjxp.supabase.co
 # NEXT_PUBLIC_VALYU_CLIENT_ID=your_client_id

--- a/README.md
+++ b/README.md
@@ -63,13 +63,9 @@ The databases exist. The archives are digitized. The APIs are built. Someone jus
 - **Multiple Map Styles** - Satellite, streets, outdoors, and more
 
 ### Save & Share
-- **Research History** - Save and revisit your discoveries (signed-in users)
+- **Research History** - Save and revisit your discoveries
 - **Shareable Links** - Generate public links to research
 - **Mobile responsive** - Works on phone/tablet/desktop
-
-### Works Anonymously
-- **1 free query** - No signup required to try it
-- **Sign up for more** - 3 free queries per day, or upgrade for unlimited
 
 ## Technology Stack
 
@@ -83,9 +79,8 @@ The databases exist. The archives are digitized. The APIs are built. Someone jus
 - **[React Markdown](https://github.com/remarkjs/react-markdown)** - Rendering research reports
 
 ### Backend
-- **[Supabase](https://supabase.com)** - Authentication and database (production mode)
-- **[SQLite](https://www.sqlite.org/)** - Local database (development mode)
-- **[Polar](https://polar.sh)** - Subscription billing
+- **[Supabase](https://supabase.com)** - Authentication and database (valyu mode)
+- **[SQLite](https://www.sqlite.org/)** - Local database (self-hosted mode)
 - **[Drizzle ORM](https://orm.drizzle.team/)** - Type-safe database queries
 
 ### Infrastructure
@@ -94,20 +89,16 @@ The databases exist. The archives are digitized. The APIs are built. Someone jus
 
 Fully open-source. Self-hostable. Model-agnostic.
 
-## Quick Start
+## Quick Start (Self-Hosted)
+
+Self-hosted mode is the recommended way to run History locally. It requires only 2 API keys and takes about 5 minutes to set up.
 
 ### Prerequisites
 
-**For Development Mode (Easiest - No Auth Required):**
 - Node.js 18+
 - pnpm, npm, or yarn
 - Valyu DeepResearch API key ([get one free at platform.valyu.ai](https://platform.valyu.ai))
 - Mapbox access token ([get one free at mapbox.com](https://account.mapbox.com))
-
-**For Production Mode:**
-- All of the above, plus:
-- Supabase account and project
-- Polar account for billing (optional)
 
 ### Installation
 
@@ -128,10 +119,9 @@ Fully open-source. Self-hostable. Model-agnostic.
 
    Create a `.env.local` file in the root directory:
 
-   **For Development Mode (Recommended for getting started):**
    ```env
-   # Development Mode - No Auth, No Billing, No Database Setup Required
-   NEXT_PUBLIC_APP_MODE=development
+   # Self-Hosted Mode - No Auth Required
+   NEXT_PUBLIC_APP_MODE=self-hosted
 
    # Valyu API (Required)
    VALYU_API_KEY=valyu_your_api_key_here
@@ -141,30 +131,6 @@ Fully open-source. Self-hostable. Model-agnostic.
 
    # App URL
    NEXT_PUBLIC_APP_URL=http://localhost:3000
-   ```
-
-   **For Production Mode:**
-   ```env
-   # Production Mode
-   NEXT_PUBLIC_APP_MODE=production
-   NEXT_PUBLIC_APP_URL=https://yourdomain.com
-
-   # Valyu API
-   VALYU_API_KEY=valyu_your_api_key_here
-
-   # Mapbox
-   NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.your_mapbox_access_token_here
-
-   # Supabase
-   NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
-   SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
-
-   # Polar Billing (Optional)
-   POLAR_ACCESS_TOKEN=polar_your_access_token_here
-   POLAR_WEBHOOK_SECRET=whsec_your_webhook_secret_here
-   POLAR_SUBSCRIPTION_PRODUCT_ID=prod_your_subscription_product_id_here
-   POLAR_PAY_PER_USE_PRODUCT_ID=prod_your_pay_per_use_product_id_here
    ```
 
 4. **Run the development server**
@@ -208,69 +174,45 @@ Fully open-source. Self-hostable. Model-agnostic.
    - Click on source citations to verify information
    - View images and visual aids (if available)
 
-5. **Save for Later** (signed-in users)
-   - Your research is automatically saved
+5. **Save for Later**
+   - Your research is automatically saved locally
    - Access past research from the sidebar
-   - Share research via shareable URLs
 
 ### Advanced Features
 
 - **Random Discovery**: Click "Random Location" to explore a random place on Earth
-- **Map Styles**: Switch between satellite, streets, and other map styles (signed-in users)
+- **Map Styles**: Switch between satellite, streets, and other map styles
 - **Reasoning View**: Click to see the detailed reasoning trace of the AI
 - **Dark Mode**: Automatically matches your system preferences
 
-## Development Modes
+## App Modes
 
-History has two operating modes to make development easy:
+History has two operating modes:
 
-### Development Mode (Default for Local Development)
+### Self-Hosted Mode (Recommended)
 ```env
-NEXT_PUBLIC_APP_MODE=development
+NEXT_PUBLIC_APP_MODE=self-hosted
 ```
 
 **Features:**
 - No Supabase required - uses local SQLite
 - No authentication needed - auto-login as dev user
 - Unlimited queries - no rate limits
-- No billing integration
+- Uses your Valyu API key directly
 - Works completely offline (except API calls)
-- Perfect for contributing and testing
+- Perfect for local usage and contributing
 
-### Production Mode
+### Valyu Mode
 ```env
-NEXT_PUBLIC_APP_MODE=production
+NEXT_PUBLIC_APP_MODE=valyu
 ```
 
+**Note:** Valyu OAuth apps will be in general availability soon. Currently client id/secret are not publicly available. Contact contact@valyu.ai if you need access.
+
 **Features:**
-- Full authentication with Supabase
-- Billing integration with Polar
-- Rate limiting based on user tiers
-- Cloud database storage
-- Analytics and tracking
-
-## Rate Limits & Billing
-
-### Anonymous Users
-- **1 query (lifetime)** - No account required
-- After first query, prompted to sign up
-
-### Free Users (Signed Up)
-- **3 queries per day** - Resets at midnight
-- Full access to research history
-- Save and share research
-
-### Subscription Plan
-- Monthly recurring with queries included
-- Free trial period
-- Priority support
-- Resets on the 1st of each month
-
-### Pay-Per-Use Plan
-- Unlimited usage
-- No monthly commitment
-- Only pay for what you use
-- Billed via Polar usage metering
+- Full authentication with Valyu OAuth
+- Cloud database storage with Supabase
+- Used for the hosted version at history.valyu.ai
 
 ## Getting API Keys
 
@@ -285,7 +227,7 @@ NEXT_PUBLIC_APP_MODE=production
 **Pricing:**
 - Free tier available for testing
 - Pay-as-you-go pricing for production
-- Lite model: approximately $0.10 per research
+- Fast model: approximately $0.10 per research
 - Heavy model: approximately $0.50 per research
 
 ### Mapbox Access Token (Required)
@@ -298,19 +240,6 @@ NEXT_PUBLIC_APP_MODE=production
 **Pricing:**
 - 50,000 free map loads per month
 - Additional usage billed per load (very affordable)
-
-### Polar Setup (Optional - For Billing)
-
-1. Go to [polar.sh](https://polar.sh)
-2. Create an account
-3. Set up two products:
-   - **Subscription Product**: Monthly recurring with free trial
-   - **Pay-Per-Use Product**: Usage-based billing
-4. Create a meter for pay-per-use:
-   - Event name: `deep_research`
-   - Aggregation: `count`
-   - Set your desired pricing per unit
-5. Add product IDs and webhook secret to `.env.local`
 
 ## Database Schema
 
@@ -372,7 +301,7 @@ History is fully open-source. Contributions are welcome and appreciated.
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Make your changes
-4. Test in development mode (`NEXT_PUBLIC_APP_MODE=development`)
+4. Test in self-hosted mode (`NEXT_PUBLIC_APP_MODE=self-hosted`)
 5. Commit your changes (`git commit -m 'Add amazing feature'`)
 6. Push to the branch (`git push origin feature/amazing-feature`)
 7. Open a Pull Request
@@ -439,8 +368,6 @@ This project was born from countless hours spent exploring Google Maps, clicking
 - **[Valyu](https://valyu.ai)** - For building an incredible DeepResearch API that makes this possible
 - **[Mapbox](https://mapbox.com)** - For beautiful, performant globe visualization
 - **[Supabase](https://supabase.com)** - For making authentication and databases simple
-- **[Polar](https://polar.sh)** - For developer-friendly billing
-- **The Geography Community** - For inspiring curiosity about our planet
 
 ---
 

--- a/src/app/api/enterprise/inquiry/route.ts
+++ b/src/app/api/enterprise/inquiry/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { EnterpriseInquiryEmail } from '@/lib/email-templates/enterprise-inquiry';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Lazy initialize Resend to avoid build-time errors when API key is not set
+const getResend = () => new Resend(process.env.RESEND_API_KEY);
 
 const ENTERPRISE_RECIPIENTS = [
   'harvey@valyu.ai',
@@ -56,7 +57,7 @@ export async function POST(req: NextRequest) {
     });
 
     // Send email to Valyu team
-    await resend.emails.send({
+    await getResend().emails.send({
       from: 'History Enterprise <support@valyu.ai>',
       to: ENTERPRISE_RECIPIENTS,
       replyTo: contactEmail,

--- a/src/app/api/reports/generate-pdf/route.ts
+++ b/src/app/api/reports/generate-pdf/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import puppeteer from 'puppeteer';
 import { remark } from 'remark';
 import html from 'remark-html';
-import { isDevelopmentMode } from '@/lib/local-db/local-auth';
+import { isSelfHostedMode } from '@/lib/local-db/local-auth';
 
 const VALYU_APP_URL = process.env.VALYU_APP_URL || 'https://platform.valyu.ai';
 const VALYU_OAUTH_PROXY_URL = `${VALYU_APP_URL}/api/oauth/proxy`;
@@ -204,10 +204,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const isDevelopment = isDevelopmentMode();
+    const isSelfHosted = isSelfHostedMode();
 
-    // Require auth token in production
-    if (!isDevelopment && !valyuAccessToken) {
+    // Require auth token in valyu mode
+    if (!isSelfHosted && !valyuAccessToken) {
       return NextResponse.json(
         { error: 'Authentication required' },
         { status: 401 }
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
 
     let response: Response;
 
-    // Fetch research data via OAuth proxy or direct API (dev mode)
+    // Fetch research data via OAuth proxy or direct API (self-hosted mode)
     if (valyuAccessToken) {
       response = await fetch(VALYU_OAUTH_PROXY_URL, {
         method: 'POST',
@@ -229,7 +229,7 @@ export async function POST(request: NextRequest) {
           method: 'GET',
         }),
       });
-    } else if (isDevelopment && VALYU_API_KEY) {
+    } else if (isSelfHosted && VALYU_API_KEY) {
       response = await fetch(
         `${DEEPRESEARCH_API_URL}/tasks/${taskId}/status`,
         {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ function HomeContent() {
 
   // Check if user is signed in with Valyu
   const isSignedIn = !!user && !!valyuAccessToken;
-  const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
+  const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
   // Handle URL messages from auth callbacks
   useEffect(() => {
@@ -86,8 +86,8 @@ function HomeContent() {
       return;
     }
 
-    // Require Valyu sign-in (except in development mode)
-    if (!isDevelopment && !isSignedIn) {
+    // Require Valyu sign-in (except in self-hosted mode)
+    if (!isSelfHosted && !isSignedIn) {
       setShowAuthModal(true);
       return;
     }
@@ -95,12 +95,12 @@ function HomeContent() {
     // Show confirmation dialog
     setConfirmLocation(location);
     setShowConfirmDialog(true);
-  }, [isSignedIn, isDevelopment]);
+  }, [isSignedIn, isSelfHosted]);
 
   const handleConfirmResearch = useCallback((instructions?: string) => {
     if (confirmLocation) {
       // Double-check sign-in before starting research
-      if (!isDevelopment && !isSignedIn) {
+      if (!isSelfHosted && !isSignedIn) {
         setShowConfirmDialog(false);
         setShowAuthModal(true);
         return;
@@ -111,7 +111,7 @@ function HomeContent() {
       setShowConfirmDialog(false);
       setConfirmLocation(null);
     }
-  }, [confirmLocation, isSignedIn, isDevelopment]);
+  }, [confirmLocation, isSignedIn, isSelfHosted]);
 
   const handleCancelResearch = useCallback(() => {
     setShowConfirmDialog(false);
@@ -182,8 +182,8 @@ function HomeContent() {
   }, []);
 
   const handleFeelingLucky = useCallback(() => {
-    // Require Valyu sign-in (except in development mode)
-    if (!isDevelopment && !isSignedIn) {
+    // Require Valyu sign-in (except in self-hosted mode)
+    if (!isSelfHosted && !isSignedIn) {
       setShowAuthModal(true);
       return;
     }
@@ -191,7 +191,7 @@ function HomeContent() {
     if (globeRef.current) {
       globeRef.current.selectRandomLocation();
     }
-  }, [isSignedIn, isDevelopment]);
+  }, [isSignedIn, isSelfHosted]);
 
   return (
     <div className="flex h-screen w-full bg-background overflow-hidden">

--- a/src/components/enterprise/enterprise-banner.tsx
+++ b/src/components/enterprise/enterprise-banner.tsx
@@ -7,8 +7,8 @@ import { EnterpriseContactModal } from './enterprise-contact-modal';
 export function EnterpriseBanner() {
   const [showModal, setShowModal] = useState(false);
 
-  // Hide in development mode or if enterprise features disabled
-  if (process.env.NEXT_PUBLIC_APP_MODE === 'development' || process.env.NEXT_PUBLIC_ENTERPRISE !== 'true') {
+  // Hide in self-hosted mode or if enterprise features disabled
+  if (process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted' || process.env.NEXT_PUBLIC_ENTERPRISE !== 'true') {
     return null;
   }
 

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -62,7 +62,7 @@ export function Sidebar({
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const isDevelopment = process.env.NEXT_PUBLIC_APP_MODE === 'development';
+  const isSelfHosted = process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
   // Keep dock open by default for everyone
   const [isOpen, setIsOpen] = useState(true);
@@ -78,7 +78,7 @@ export function Sidebar({
   const { data: tasks = [], isLoading: loadingTasks } = useQuery({
     queryKey: ['research-tasks'],
     queryFn: async () => {
-      if (isDevelopment) {
+      if (isSelfHosted) {
         const response = await fetch('/api/research/tasks');
         const { tasks } = await response.json();
         return tasks;
@@ -94,7 +94,7 @@ export function Sidebar({
       const { tasks } = await response.json();
       return tasks;
     },
-    enabled: isDevelopment || !!user,
+    enabled: isSelfHosted || !!user,
     refetchInterval: 5000, // Refresh every 5 seconds to update status badges
   });
 
@@ -273,7 +273,7 @@ export function Sidebar({
               <div className="w-10 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
 
               {/* New Research */}
-              {(user || isDevelopment) && (
+              {(user || isSelfHosted) && (
                 <div className="relative group/tooltip">
                   <button
                     onClick={handleNewResearch}
@@ -291,14 +291,14 @@ export function Sidebar({
               <div className="relative group/tooltip">
                 <button
                   onClick={() => {
-                    if (!user && !isDevelopment) {
+                    if (!user && !isSelfHosted) {
                       window.dispatchEvent(new CustomEvent('show-auth-modal'));
                     } else {
                       setShowHistory(!showHistory);
                     }
                   }}
                   className={`w-12 h-12 flex items-center justify-center rounded-[20px] transition-all duration-200 hover:scale-110 active:scale-95 ${
-                    !user && !isDevelopment
+                    !user && !isSelfHosted
                       ? 'opacity-50 cursor-not-allowed hover:bg-accent'
                       : showHistory
                         ? 'bg-primary text-primary-foreground shadow-lg'
@@ -306,7 +306,7 @@ export function Sidebar({
                   }`}
                 >
                   <History className={`h-6 w-6 transition-colors ${
-                    !user && !isDevelopment
+                    !user && !isSelfHosted
                       ? 'text-muted-foreground/50'
                       : showHistory
                         ? 'text-primary-foreground'
@@ -314,15 +314,15 @@ export function Sidebar({
                   }`} />
                 </button>
                 <div className="absolute left-full ml-3 top-1/2 -translate-y-1/2 px-3 py-1.5 bg-popover text-popover-foreground text-sm font-medium rounded-lg opacity-0 group-hover/tooltip:opacity-100 pointer-events-none transition-opacity whitespace-nowrap z-50 border border-border shadow-md">
-                  {!user && !isDevelopment ? 'Sign up (free) for history' : 'Research History'}
+                  {!user && !isSelfHosted ? 'Sign up (free) for history' : 'Research History'}
                 </div>
               </div>
 
               {/* Divider */}
-              {user && !isDevelopment && <div className="w-10 h-px bg-gradient-to-r from-transparent via-border to-transparent my-1" />}
+              {user && !isSelfHosted && <div className="w-10 h-px bg-gradient-to-r from-transparent via-border to-transparent my-1" />}
 
-              {/* Valyu Credits - Hidden in development mode */}
-              {user && !isDevelopment && (
+              {/* Valyu Credits - Hidden in self-hosted mode */}
+              {user && !isSelfHosted && (
                 <div className="relative group/tooltip">
                   <button
                     onClick={handleManageCredits}
@@ -337,7 +337,7 @@ export function Sidebar({
               )}
 
               {/* Enterprise */}
-              {user && process.env.NEXT_PUBLIC_APP_MODE !== 'development' && process.env.NEXT_PUBLIC_ENTERPRISE === 'true' && (
+              {user && process.env.NEXT_PUBLIC_APP_MODE !== 'self-hosted' && process.env.NEXT_PUBLIC_ENTERPRISE === 'true' && (
                 <div className="relative group/tooltip">
                   <button
                     onClick={() => setShowEnterpriseModal(true)}
@@ -510,7 +510,7 @@ export function Sidebar({
 
       {/* Research History Panel - Hidden on mobile */}
       <AnimatePresence>
-        {showHistory && (user || isDevelopment) && (
+        {showHistory && (user || isSelfHosted) && (
           <>
             {/* Backdrop */}
             <motion.div

--- a/src/components/user/subscription-modal.tsx
+++ b/src/components/user/subscription-modal.tsx
@@ -151,7 +151,7 @@ export function SubscriptionModal({ open, onClose }: SubscriptionModalProps) {
             </div>
 
             {/* Enterprise Option */}
-            {process.env.NEXT_PUBLIC_APP_MODE !== 'development' && process.env.NEXT_PUBLIC_ENTERPRISE === 'true' && (
+            {process.env.NEXT_PUBLIC_APP_MODE !== 'self-hosted' && process.env.NEXT_PUBLIC_ENTERPRISE === 'true' && (
               <motion.div
                 className="relative group cursor-pointer"
                 whileHover={{ y: -2 }}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,11 +1,11 @@
 /**
- * Unified database interface that switches between Supabase (production)
- * and SQLite (development) based on NEXT_PUBLIC_APP_MODE
+ * Unified database interface that switches between Supabase (valyu mode)
+ * and SQLite (self-hosted mode) based on NEXT_PUBLIC_APP_MODE
  */
 
 import { createClient as createSupabaseClient } from "@/utils/supabase/server";
 import { getLocalDb, DEV_USER_ID } from "./local-db/client";
-import { getDevUser, isDevelopmentMode } from "./local-db/local-auth";
+import { getDevUser, isSelfHostedMode } from "./local-db/local-auth";
 import { eq, desc, and } from "drizzle-orm";
 import * as schema from "./local-db/schema";
 
@@ -14,7 +14,7 @@ import * as schema from "./local-db/schema";
 // ============================================================================
 
 export async function getUser() {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     return { data: { user: getDevUser() }, error: null };
   }
 
@@ -23,7 +23,7 @@ export async function getUser() {
 }
 
 export async function getSession() {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     return {
       data: {
         session: {
@@ -44,7 +44,7 @@ export async function getSession() {
 // ============================================================================
 
 export async function getUserProfile(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const user = await db.query.users.findFirst({
       where: eq(schema.users.id, userId),
@@ -66,7 +66,7 @@ export async function getUserProfile(userId: string) {
 // ============================================================================
 
 export async function getUserRateLimit(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const rateLimit = await db.query.userRateLimits.findFirst({
       where: eq(schema.userRateLimits.userId, userId),
@@ -87,7 +87,7 @@ export async function updateUserRateLimit(
   userId: string,
   updates: { usage_count?: number; reset_date?: string; last_request_at?: Date }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .update(schema.userRateLimits)
@@ -113,7 +113,7 @@ export async function updateUserRateLimit(
 // ============================================================================
 
 export async function getChatSessions(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const sessions = await db.query.chatSessions.findMany({
       where: eq(schema.chatSessions.userId, userId),
@@ -132,7 +132,7 @@ export async function getChatSessions(userId: string) {
 }
 
 export async function getChatSession(sessionId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const session = await db.query.chatSessions.findFirst({
       where: and(
@@ -158,7 +158,7 @@ export async function createChatSession(session: {
   user_id: string;
   title: string;
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.chatSessions).values({
       id: session.id,
@@ -178,7 +178,7 @@ export async function updateChatSession(
   userId: string,
   updates: { title?: string; last_message_at?: Date }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const updateData: any = {
       updatedAt: new Date(),
@@ -209,7 +209,7 @@ export async function updateChatSession(
 }
 
 export async function deleteChatSession(sessionId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .delete(schema.chatSessions)
@@ -236,7 +236,7 @@ export async function deleteChatSession(sessionId: string, userId: string) {
 // ============================================================================
 
 export async function getChatMessages(sessionId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const messages = await db.query.chatMessages.findMany({
       where: eq(schema.chatMessages.sessionId, sessionId),
@@ -264,7 +264,7 @@ export async function saveChatMessages(
   }>
 ) {
 
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
 
     // Delete existing messages
@@ -315,7 +315,7 @@ export async function saveChatMessages(
 }
 
 export async function deleteChatMessages(sessionId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db
       .delete(schema.chatMessages)
@@ -336,7 +336,7 @@ export async function deleteChatMessages(sessionId: string) {
 // ============================================================================
 
 export async function getChart(chartId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const chart = await db.query.charts.findFirst({
       where: eq(schema.charts.id, chartId),
@@ -360,7 +360,7 @@ export async function createChart(chart: {
   session_id: string;
   chart_data: any;
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.charts).values({
       id: chart.id,
@@ -382,7 +382,7 @@ export async function createChart(chart: {
 // ============================================================================
 
 export async function getCSV(csvId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const csv = await db.query.csvs.findFirst({
       where: eq(schema.csvs.id, csvId),
@@ -409,7 +409,7 @@ export async function createCSV(csv: {
   headers: string[];
   rows: any[][];
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.csvs).values({
       id: csv.id,
@@ -434,7 +434,7 @@ export async function createCSV(csv: {
 // ============================================================================
 
 export async function getResearchTasks(userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const tasks = await db.query.researchTasks.findMany({
       where: eq(schema.researchTasks.userId, userId),
@@ -455,7 +455,7 @@ export async function getResearchTasks(userId: string) {
 }
 
 export async function getResearchTask(taskId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const task = await db.query.researchTasks.findFirst({
       where: eq(schema.researchTasks.id, taskId),
@@ -482,7 +482,7 @@ export async function createResearchTask(task: {
   status?: string;
   anonymous_id?: string;
 }) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.insert(schema.researchTasks).values({
       id: task.id,
@@ -510,7 +510,7 @@ export async function updateResearchTask(
     location_images?: string;
   }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const updateData: any = {
       updatedAt: new Date(),
@@ -543,7 +543,7 @@ export async function updateResearchTaskByDeepResearchId(
     completed_at?: Date | null;
   }
 ) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const updateData: any = {
       updatedAt: new Date(),
@@ -578,7 +578,7 @@ function createLocationSlug(locationName: string): string {
 
 // Share a research task publicly
 export async function shareResearchTask(taskId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
 
     // Get the task to access location_name
@@ -641,7 +641,7 @@ export async function shareResearchTask(taskId: string, userId: string) {
 
 // Unshare a research task
 export async function unshareResearchTask(taskId: string, userId: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     await db.update(schema.researchTasks)
       .set({
@@ -669,7 +669,7 @@ export async function unshareResearchTask(taskId: string, userId: string) {
 
 // Get a public research task by share token (no auth required)
 export async function getPublicResearchTask(shareToken: string) {
-  if (isDevelopmentMode()) {
+  if (isSelfHostedMode()) {
     const db = getLocalDb();
     const [task] = await db.select()
       .from(schema.researchTasks)

--- a/src/lib/local-db/local-auth.ts
+++ b/src/lib/local-db/local-auth.ts
@@ -1,6 +1,6 @@
 import { DEV_USER_ID, DEV_USER_EMAIL } from "./client";
 
-// Mock auth session for development mode
+// Mock auth session for self-hosted mode
 export interface LocalAuthSession {
   user: {
     id: string;
@@ -20,7 +20,7 @@ export function getDevSession(): LocalAuthSession {
   };
 }
 
-// Mock auth user for development mode
+// Mock auth user for self-hosted mode
 export function getDevUser() {
   return {
     id: DEV_USER_ID,
@@ -28,7 +28,7 @@ export function getDevUser() {
   };
 }
 
-// Check if we're in development mode
-export function isDevelopmentMode(): boolean {
-  return process.env.NEXT_PUBLIC_APP_MODE === "development";
+// Check if we're in self-hosted mode
+export function isSelfHostedMode(): boolean {
+  return process.env.NEXT_PUBLIC_APP_MODE === "self-hosted";
 }

--- a/src/utils/supabase/client-wrapper.ts
+++ b/src/utils/supabase/client-wrapper.ts
@@ -1,6 +1,6 @@
 /**
- * Client-side database wrapper that switches between Supabase (production)
- * and local mock (development) based on NEXT_PUBLIC_APP_MODE
+ * Client-side database wrapper that switches between Supabase (valyu mode)
+ * and local mock (self-hosted mode) based on NEXT_PUBLIC_APP_MODE
  */
 
 import { createClient as createSupabaseClient } from './client';
@@ -9,9 +9,9 @@ import { createClient as createSupabaseClient } from './client';
 const DEV_USER_ID = "dev-user-00000000-0000-0000-0000-000000000000";
 const DEV_USER_EMAIL = "dev@localhost";
 
-const isDevelopment = () => process.env.NEXT_PUBLIC_APP_MODE === 'development';
+const isSelfHosted = () => process.env.NEXT_PUBLIC_APP_MODE === 'self-hosted';
 
-// Mock auth object for development mode
+// Mock auth object for self-hosted mode
 const createDevAuth = () => ({
   getUser: async () => ({
     data: {
@@ -152,8 +152,8 @@ const createDevAuth = () => ({
 });
 
 export function createClient() {
-  if (isDevelopment()) {
-    // Return mock Supabase client for development
+  if (isSelfHosted()) {
+    // Return mock Supabase client for self-hosted mode
     return {
       auth: createDevAuth(),
       // Mock other methods that might be used


### PR DESCRIPTION
## Summary
- Rename app modes for clarity: development -> self-hosted, production -> valyu
- Update all code references, .env.example, and README
- Focus documentation on self-hosted mode as primary usage
- De-emphasize valyu mode (OAuth apps coming to general availability soon)

## Changes
- Rename isDevelopmentMode() to isSelfHostedMode()
- Update NEXT_PUBLIC_APP_MODE values throughout codebase
- Update .env.example with self-hosted focus
- Update README with clear self-hosted setup instructions

Note: Valyu OAuth apps will be in general availability soon. Contact contact@valyu.ai if you need access now.