### PR TITLE
Add disable Wikipedia option to research submission modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ docs/
 
 # local development database
 .local-data/
+
+# claude code
+.claude/

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ function HomeContent() {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [confirmLocation, setConfirmLocation] = useState<{ name: string; lat: number; lng: number } | null>(null);
   const [customInstructions, setCustomInstructions] = useState<string | undefined>(undefined);
+  const [excludedSources, setExcludedSources] = useState<string[] | undefined>(undefined);
   const [globeTheme, setGlobeTheme] = useState<GlobeTheme>('satellite-streets-v12');
   const globeRef = useRef<any>(null);
   const [showMobileSettings, setShowMobileSettings] = useState(false);
@@ -97,7 +98,7 @@ function HomeContent() {
     setShowConfirmDialog(true);
   }, [isSignedIn, isSelfHosted]);
 
-  const handleConfirmResearch = useCallback((instructions?: string) => {
+  const handleConfirmResearch = useCallback((instructions?: string, sources?: string[]) => {
     if (confirmLocation) {
       // Double-check sign-in before starting research
       if (!isSelfHosted && !isSignedIn) {
@@ -107,6 +108,7 @@ function HomeContent() {
       }
 
       setCustomInstructions(instructions);
+      setExcludedSources(sources);
       setSelectedLocation(confirmLocation);
       setShowConfirmDialog(false);
       setConfirmLocation(null);
@@ -305,6 +307,7 @@ function HomeContent() {
               }}
               initialTaskId={searchParams.get('research') || undefined}
               customInstructions={customInstructions}
+              excludedSources={excludedSources}
             />
           </motion.div>
         )}

--- a/src/components/history-research-interface.tsx
+++ b/src/components/history-research-interface.tsx
@@ -66,6 +66,7 @@ interface HistoryResearchInterfaceProps {
   initialTaskId?: string;
   customInstructions?: string;
   initialImages?: string[];
+  excludedSources?: string[];
 }
 
 const AnimatedDots = ({ isActive }: { isActive: boolean }) => {
@@ -247,7 +248,7 @@ const TimelineItem = ({ item, idx, timeline, animated = true }: { item: any; idx
   return null;
 };
 
-export function HistoryResearchInterface({ location, onClose, onTaskCreated, initialTaskId, customInstructions, initialImages }: HistoryResearchInterfaceProps) {
+export function HistoryResearchInterface({ location, onClose, onTaskCreated, initialTaskId, customInstructions, initialImages, excludedSources }: HistoryResearchInterfaceProps) {
   const { user, valyuAccessToken } = useAuthStore();
   const [status, setStatus] = useState<'idle' | 'queued' | 'running' | 'completed' | 'error'>('idle');
   const [showMiniGlobe, setShowMiniGlobe] = useState(true);
@@ -587,6 +588,7 @@ export function HistoryResearchInterface({ location, onClose, onTaskCreated, ini
             ],
             location,
             valyuAccessToken,
+            excludedSources,
           }),
         });
 

--- a/src/components/research-confirmation-dialog.tsx
+++ b/src/components/research-confirmation-dialog.tsx
@@ -82,7 +82,7 @@ export function ResearchConfirmationDialog({
   const { user } = useAuthStore();
   const [selectedPreset, setSelectedPreset] = useState<string>('general');
   const [customInstructions, setCustomInstructions] = useState('');
-  const [showCustom, setShowCustom] = useState(false);
+  const [showCustom, setShowCustom] = useState(true);
   const [wikipediaDisabled, setWikipediaDisabled] = useState(false);
 
   if (!location) return null;
@@ -167,7 +167,7 @@ export function ResearchConfirmationDialog({
                 onClick={() => setShowCustom(!showCustom)}
                 className="w-full flex items-center justify-between text-[10px] sm:text-xs font-medium text-muted-foreground hover:text-foreground transition-colors min-h-9"
               >
-                <span>Custom instructions</span>
+                <span>Custom instructions (optional)</span>
                 <ChevronDown className={`h-3 w-3 transition-transform flex-shrink-0 ${showCustom ? 'rotate-180' : ''}`} />
               </button>
 

--- a/src/components/research-confirmation-dialog.tsx
+++ b/src/components/research-confirmation-dialog.tsx
@@ -6,10 +6,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { X, ChevronDown, Sparkles } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuthStore } from '@/lib/stores/use-auth-store';
+import { Favicon } from '@/components/ui/favicon';
 
 interface ResearchConfirmationDialogProps {
   location: { name: string; lat: number; lng: number } | null;
-  onConfirm: (customInstructions?: string) => void;
+  onConfirm: (customInstructions?: string, excludedSources?: string[]) => void;
   onCancel: () => void;
   onSignUp?: () => void;
 }
@@ -82,15 +83,17 @@ export function ResearchConfirmationDialog({
   const [selectedPreset, setSelectedPreset] = useState<string>('general');
   const [customInstructions, setCustomInstructions] = useState('');
   const [showCustom, setShowCustom] = useState(false);
+  const [wikipediaDisabled, setWikipediaDisabled] = useState(false);
 
   if (!location) return null;
 
   const handleConfirm = () => {
+    const excludedSources = wikipediaDisabled ? ['wikipedia.org'] : undefined;
     if (customInstructions.trim()) {
-      onConfirm(customInstructions.trim());
+      onConfirm(customInstructions.trim(), excludedSources);
     } else {
       const preset = PRESETS.find(p => p.id === selectedPreset);
-      onConfirm(preset?.prompt);
+      onConfirm(preset?.prompt, excludedSources);
     }
   };
 
@@ -189,6 +192,26 @@ export function ResearchConfirmationDialog({
                   </motion.div>
                 )}
               </AnimatePresence>
+            </div>
+
+            {/* Source Exclusions */}
+            <div>
+              <label className="block text-[10px] sm:text-xs font-medium text-muted-foreground mb-1.5 sm:mb-2">
+                Exclude sources (optional)
+              </label>
+              <div className="flex flex-wrap gap-1.5 sm:gap-2">
+                <button
+                  onClick={() => setWikipediaDisabled(!wikipediaDisabled)}
+                  className={`flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 text-[10px] sm:text-xs font-medium rounded-lg transition-all border min-h-8 ${
+                    wikipediaDisabled
+                      ? 'bg-destructive/10 text-destructive border-destructive/30 line-through'
+                      : 'bg-card text-card-foreground border-border hover:bg-accent hover:text-accent-foreground'
+                  }`}
+                >
+                  <Favicon url="https://wikipedia.org" className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+                  <span>Wikipedia</span>
+                </button>
+              </div>
             </div>
           </div>
 

--- a/src/components/research-confirmation-dialog.tsx
+++ b/src/components/research-confirmation-dialog.tsx
@@ -258,7 +258,7 @@ export function ResearchConfirmationDialog({
                   value={excludeUrlInput}
                   onChange={(e) => setExcludeUrlInput(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddExcludeUrl())}
-                  placeholder="e.g., reddit.com, quora.com"
+                  placeholder="Enter domain to exclude... e.g., reddit.com"
                   className="flex-1 px-2.5 py-1.5 text-[10px] sm:text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-primary min-h-8"
                 />
                 <Button

--- a/src/components/research-confirmation-dialog.tsx
+++ b/src/components/research-confirmation-dialog.tsx
@@ -258,7 +258,7 @@ export function ResearchConfirmationDialog({
                   value={excludeUrlInput}
                   onChange={(e) => setExcludeUrlInput(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddExcludeUrl())}
-                  placeholder="Enter domain to exclude..."
+                  placeholder="e.g., reddit.com, quora.com"
                   className="flex-1 px-2.5 py-1.5 text-[10px] sm:text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-primary min-h-8"
                 />
                 <Button


### PR DESCRIPTION
## Summary
- Add Wikipedia toggle button with favicon to research confirmation dialog
- When toggled, passes `wikipedia.org` to `excluded_sources` param of DeepResearch API
- Add `.claude/` to gitignore

## Test plan
- [ ] Open research confirmation dialog by clicking a location
- [ ] Verify Wikipedia toggle button appears with favicon
- [ ] Toggle the button and confirm it shows strikethrough styling
- [ ] Start research with Wikipedia disabled and verify API receives `excluded_sources`
- [ ] Start research without toggling and verify no `excluded_sources` is sent