### PR TITLE
Improve auth session expiration messaging

### DIFF
--- a/src/components/history-research-interface.tsx
+++ b/src/components/history-research-interface.tsx
@@ -413,6 +413,12 @@ export function HistoryResearchInterface({ location, onClose, onTaskCreated, ini
       }
       const response = await fetch(`/api/chat/poll?taskId=${taskId}`, { headers });
       if (!response.ok) {
+        // Handle authentication errors
+        if (response.status === 401) {
+          const authError = new Error('Your session has expired. Please sign in again.');
+          (authError as any).isAuth = true;
+          throw authError;
+        }
         throw new Error('Failed to poll task status');
       }
 
@@ -750,6 +756,10 @@ export function HistoryResearchInterface({ location, onClose, onTaskCreated, ini
             }
           }
         } catch (err) {
+          // Handle auth errors specially
+          if ((err as any).isAuth) {
+            window.dispatchEvent(new CustomEvent('show-auth-modal'));
+          }
           setError(err instanceof Error ? err.message : 'Polling error');
           setStatus('error');
           setShouldContinuePolling(false);


### PR DESCRIPTION
## Summary
- Update error handling when auth session expires during research polling
- Show "Your session has expired. Please sign in again." instead of generic "Research failed" error
- Trigger auth modal to prompt user to re-authenticate

## Changes
- Modified pollTaskStatus to detect 401 errors and create specific auth error
- Updated polling error handler to trigger auth modal for auth errors
- Improved user experience when session expires mid-research

## Test plan
- [x] Session expiration now shows clear message
- [x] Auth modal triggers automatically
- [x] User can re-authenticate and continue