### PR TITLE
Add report generation time estimate message

### DIFF
--- a/src/components/history-research-interface.tsx
+++ b/src/components/history-research-interface.tsx
@@ -1060,6 +1060,9 @@ export function HistoryResearchInterface({ location, onClose, onTaskCreated, ini
                         <p className="text-xs sm:text-sm font-light text-foreground/60">
                           Generating report...
                         </p>
+                        <p className="text-[10px] sm:text-xs font-light text-foreground/40 mt-1.5">
+                          Reports take roughly 5 minutes. Images and progress will stream in shortly.
+                        </p>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Adds a subtitle under "Generating report..." that tells users reports take roughly 5 minutes and that images + progress will stream in shortly
- Reduces user confusion during the initial loading state when no text content is visible yet

## Test plan
- [ ] Trigger a new report generation and verify the message appears below "Generating report..."
- [ ] Check responsive sizing on mobile (text-[10px]) and desktop (text-xs)