### PR TITLE
Fix wildcard CORS on history.valyu.ai

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,19 @@ const nextConfig: NextConfig = {
     maxInactiveAge: 60 * 1000, // Increased to 60 seconds to prevent page disposal when switching tabs
     pagesBufferLength: 5, // Increased buffer to keep more pages in memory
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Access-Control-Allow-Origin',
+            value: 'https://history.valyu.ai',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Override Vercel's default `Access-Control-Allow-Origin: *` header on prerendered pages
- Set CORS origin to `https://history.valyu.ai` only, blocking cross-origin data access from attacker-controlled origins
- Addresses V-107 security finding

## Test plan
- [ ] Deploy preview and verify `Access-Control-Allow-Origin` header is `https://history.valyu.ai` not `*`
- [ ] Verify app functions normally (same-origin requests unaffected by CORS)